### PR TITLE
👷 Make pre-commit run on all push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,18 +2,7 @@
 
 name: Test
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
+on: [push]
 
 jobs:
   pre-commit:


### PR DESCRIPTION


## Description

<!-- Concisely describe what the pull request does. -->
This makes pre-commit run on all push events, not only on main. As a consequence, pre-commit was removed from the PR events, since this would only be duplicates with the push events.

## Definition of Done

<!-- Check the boxes (replace the [ ] with [x]) corresponding to what you've done. -->
<!-- You must have followed the repository practices, but the other items can be skipped if your work doesn't require them. -->

- [x] I followed the repository practices (e.g. I used gitmojis).
- [ ] I have added/updated tests according to my changes.
- [ ] I have added/updated documentation according to my changes.
